### PR TITLE
Changes value to library reference when getting books

### DIFF
--- a/book.go
+++ b/book.go
@@ -36,9 +36,9 @@ func init() {
 }
 
 func get(id string) (book *Book) {
-	for _, l := range lib {
+	for i, l := range lib {
 		if l.Self.ID == id {
-			book = &l
+			book = &lib[i]
 			break
 		}
 	}


### PR DESCRIPTION
### The problem:
When checking out a book, the history is not updated. 
This is because the 'book' we're updating is actually a copy of the value in the library
```go
for _, v := range lib {
 	book = &v
}
```

### The solution:
Using the index in the for loop instead passes the reference:
```go
for i, _ := range lib {
 	book = &lib[i]
}
```